### PR TITLE
Display add registrar button, add skeleton for 'add domain'

### DIFF
--- a/src/app/components/domains/create-domain/create-domain.component.html
+++ b/src/app/components/domains/create-domain/create-domain.component.html
@@ -1,8 +1,6 @@
-<div class="add-btn-container">
-  <button class="btn btn-primary btn-add" (click)="open(content)">
-    Add Domain
-  </button>
-</div>
+<button class="btn btn-primary btn-add" (click)="open(content)">
+  Add Domain
+</button>
 
 <ng-template #content let-modal>
   <div class="modal-header">
@@ -16,7 +14,102 @@
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
-  <div class="modal-body"></div>
+  <div class="modal-body">
+    <form [formGroup]="domainForm" (ngSubmit)="onSubmit()">
+      <!-- Name input -->
+      <div class="form-group">
+        <label for="name" class="d-none">Name</label>
+        <input
+          type="text"
+          class="form-control"
+          formControlName="name"
+          class="form-control"
+          [ngClass]="{
+            'is-invalid': submitted && errors.name
+          }"
+          placeholder="Name"
+        />
+        <div *ngIf="submitted && errors.name" class="invalid-feedback">
+          <div *ngIf="errors.name.required">
+            Name is required
+          </div>
+        </div>
+      </div>
+      <!-- Name input end -->
+      <!-- Registrar input -->
+      <div class="form-group">
+        <label for="registrar-input" class="d-none">Registrar</label>
+        <select
+          class="custom-select"
+          [ngClass]="{
+            'is-invalid': submitted && errors.registrar
+          }"
+          id="registrar-input"
+          formControlName="registrar"
+        >
+          <option value="" disabled hidden selected>Select registrar</option>
+          <ng-container *ngFor="let registrar of registrar$ | async as list">
+            <option value="{{ registrar.class }}">{{ registrar.label }}</option>
+          </ng-container>
+        </select>
+        <div
+          *ngIf="submitted && errors.registrar"
+          class="invalid-feedback d-block"
+        >
+          <div *ngIf="errors.registrar.required">
+            Registrar needs to be selected
+          </div>
+        </div>
+      </div>
+      <!-- Registrar input end -->
+      <!-- Dns input -->
+      <div class="form-group">
+        <label for="dns-input" class="d-none">dns</label>
+        <select
+          class="custom-select"
+          [ngClass]="{
+            'is-invalid': submitted && errors.dns
+          }"
+          id="dns-input"
+          formControlName="dns"
+        >
+          <option value="" disabled hidden selected>Select Dns</option>
+          <ng-container *ngFor="let dns of dns$ | async as list">
+            <option value="{{ dns.class }}">{{ dns.label }}</option>
+          </ng-container>
+        </select>
+        <div *ngIf="submitted && errors.dns" class="invalid-feedback d-block">
+          <div *ngIf="errors.dns.required">
+            Dns needs to be selected
+          </div>
+        </div>
+      </div>
+      <!-- Dns input end -->
+      <!-- Waf input-->
+      <div class="form-group">
+        <label for="waf-input" class="d-none">Waf</label>
+        <select
+          class="custom-select"
+          [ngClass]="{
+            'is-invalid': submitted && errors.waf
+          }"
+          id="waf-input"
+          formControlName="waf"
+        >
+          <option value="" disabled hidden selected>Select waf</option>
+          <ng-container *ngFor="let waf of waf$ | async as list">
+            <option value="{{ waf.class }}">{{ waf.label }}</option>
+          </ng-container>
+        </select>
+        <div *ngIf="submitted && errors.waf" class="invalid-feedback d-block">
+          <div *ngIf="errors.waf.required">
+            Waf needs to be selected
+          </div>
+        </div>
+      </div>
+      <!-- Waf input end -->
+    </form>
+  </div>
   <div class="modal-footer">
     <img
       *ngIf="creating"
@@ -26,7 +119,7 @@
     <button
       type="button"
       class="btn btn-outline-dark"
-      (click)="addRegistrar()"
+      (click)="addDomain()"
       [disabled]="creating"
     >
       Save

--- a/src/app/components/domains/create-domain/create-domain.component.ts
+++ b/src/app/components/domains/create-domain/create-domain.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { AgentsService } from 'src/app/services/agents.service';
+import { Observable } from 'rxjs';
+import { Agent } from 'src/app/models/Agent';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-create-domain',
@@ -7,11 +11,33 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
   styleUrls: ['./create-domain.component.css'],
 })
 export class CreateDomainComponent implements OnInit {
-  constructor(private modalService: NgbModal) {}
+  name: string;
+  registrar$: Observable<Agent[]>;
+  dns$: Observable<Agent[]>;
+  site: number;
+  waf$: Observable<Agent[]>;
+  domainForm: FormGroup;
+  constructor(
+    private modalService: NgbModal,
+    private agentService: AgentsService,
+    private fb: FormBuilder
+  ) {
+    this.domainForm = this.fb.group({
+      dns: [''],
+      waf: [''],
+      registrar: [''],
+      name: ['', Validators.required],
+    });
+  }
 
   open(content) {
     this.modalService.open(content, { ariaLabelledBy: 'modal-title' });
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.agentService.loadAll();
+    this.registrar$ = this.agentService.registrarAgents;
+    this.dns$ = this.agentService.dnsAgents;
+    this.waf$ = this.agentService.wafAgents;
+  }
 }

--- a/src/app/components/domains/domains.component.html
+++ b/src/app/components/domains/domains.component.html
@@ -1,16 +1,18 @@
-<label>
-  Name:
-  <input type="text" [formControl]="searchTerm" (keyup.enter)="search()" />
-</label>
-<p>
-  <button (click)="search()">Search</button>
-</p>
+<div class="container">
+  <label>
+    Name:
+    <input type="text" [formControl]="searchTerm" (keyup.enter)="search()" />
+  </label>
+  <p>
+    <button (click)="search()">Search</button>
+    <app-create-domain></app-create-domain>
+  </p>
+</div>
 
 <div
   class="container"
   *ngIf="!loading && domains$ | async as domains; else notready"
 >
-  <app-create-domain></app-create-domain>
   <ng-container *ngIf="domains.length; else notready">
     <!--Table-->
     <table class="table table-hover table-fixed">

--- a/src/app/components/registrars/create-registrar/create-registrar.component.html
+++ b/src/app/components/registrars/create-registrar/create-registrar.component.html
@@ -41,10 +41,10 @@
         <select
           class="custom-select"
           [ngClass]="{
-            'is-invalid': submitted && errors.agent_module
+            'is-invalid': submitted && errors.agent
           }"
           id="agent-input"
-          formControlName="agent_module"
+          formControlName="agent"
         >
           <option value="" disabled hidden selected>Select agent</option>
           <ng-container *ngFor="let agent of agents | async as list">

--- a/src/app/components/registrars/create-registrar/create-registrar.component.ts
+++ b/src/app/components/registrars/create-registrar/create-registrar.component.ts
@@ -30,7 +30,7 @@ export class CreateRegistrarComponent implements OnInit {
   ) {
     this.newRegistrarForm = this.formBuilder.group({
       label: ['', Validators.required],
-      agent_module: ['', Validators.required],
+      agent: ['', Validators.required],
     });
   }
 
@@ -42,7 +42,7 @@ export class CreateRegistrarComponent implements OnInit {
   get errors(): { [key: string]: ValidationErrors } {
     return {
       label: this.newRegistrarForm.controls.label.errors,
-      agent_module: this.newRegistrarForm.controls.agent.errors,
+      agent: this.newRegistrarForm.controls.agent.errors,
     };
   }
 

--- a/src/app/components/registrars/registrars.component.html
+++ b/src/app/components/registrars/registrars.component.html
@@ -8,9 +8,14 @@
 </p>
 -->
 
-  <!-- Search results container -->
-  <div class="container my-3" *ngIf="!loading && registrars$ | async as registrars; else notready">
-    <div class="table-responsive">
+<!-- Search results container -->
+<div
+  class="container my-3"
+  *ngIf="!loading && registrars$ | async as registrars; else notready"
+>
+  <app-create-registrar></app-create-registrar>
+  <ng-container>
+    <div class="table-responsive" *ngIf="registrars.length > 0">
       <!-- Search results table -->
       <table class="table table-hover table-fixed table-striped">
         <thead class="thead-light">
@@ -20,18 +25,27 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let registrar of registrars; index as registrarId" routerLink="/registrars/{{ registrar.id }}">
-            <th scope="row"><span class="badge badge-secondary">{{ registrar.id }}</span></th>
+          <tr
+            *ngFor="let registrar of registrars; index as registrarId"
+            routerLink="/registrars/{{ registrar.id }}"
+          >
+            <th scope="row">
+              <span class="badge badge-secondary">{{ registrar.id }}</span>
+            </th>
             <td>{{ registrar.label }}</td>
           </tr>
         </tbody>
       </table>
     </div>
+  </ng-container>
 </div>
 
 <ng-template #notready>
   <div *ngIf="loading">
-    <img class="pl-3" src="data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA=="/>
+    <img
+      class="pl-3"
+      src="data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA=="
+    />
   </div>
   <p *ngIf="!loading">No registrars found.</p>
 </ng-template>

--- a/src/app/services/registrars.service.ts
+++ b/src/app/services/registrars.service.ts
@@ -69,7 +69,6 @@ export class RegistrarsService {
    * Getter for single registrar
    */
   get registrar(): Observable<Registrar> {
-    this.loading.single = true;
     return this.registrars$.pipe(
       map((registrars: Registrar[]) =>
         registrars.find((registrar: Registrar) => {


### PR DESCRIPTION
Merging branch from `the-junglist` caused overwrite of registrars component. In this PR added `add registrar` component again to list markup and created skeleton for add domain UI.  Still, I will need some API endpoints description( request schema ) for general entities ( `domains`, `sites` )